### PR TITLE
Refactor workflow to Dockerfile + Make targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.env
+.venv/
+env/
+logs/
+outputs/
+data/
+notebooks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["pytest", "-q", "tests"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,32 @@
+IMAGE_NAME ?= tvsd-benchmark
+IMAGE_TAG ?= latest
+
+DOCKER_IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
+
+.PHONY: help build test test-local shell cleanlogs cleantimm
+
+help:
+	@echo "Available targets:"
+	@echo "  make build      Build Docker image ($(DOCKER_IMAGE))"
+	@echo "  make test       Run unit tests in Docker"
+	@echo "  make test-local Run unit tests locally"
+	@echo "  make shell      Open an interactive shell in the Docker image"
+	@echo "  make cleanlogs  Remove logs/*"
+	@echo "  make cleantimm  Remove configs/timm/*"
+
+build:
+	docker build -t $(DOCKER_IMAGE) .
+
+test:
+	docker run --rm $(DOCKER_IMAGE) pytest -q tests
+
+test-local:
+	pytest -q tests
+
+shell:
+	docker run --rm -it $(DOCKER_IMAGE) /bin/bash
+
 # cleanlogs: get rid of contents of logs/
-.PHONY: cleanlogs
 cleanlogs:
 	rm -rf logs/*
 	@echo "Logs directory cleaned"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ Begin by cloning the repository.
 git clone git@github.com:serre-lab/tvsd-benchmark.git
 cd tvsd-benchmark
 ```
-Next, create a `conda` environment with our requirements.
+
+### Option 1: Docker + Make (recommended)
+Build the container image and run the unit tests:
+```bash
+make build
+make test
+```
+Open a shell in the container:
+```bash
+make shell
+```
+
+### Option 2: Local Python environment
+Create a `conda` environment with our requirements.
 ```bash
 conda create -n tvsd-benchmark
 conda activate tvsd-benchmark
@@ -34,7 +47,7 @@ chmod +x scripts/download_things.sh
 
 ## Benchmarking a Model
 
-Ensure that you have your virtual envirovnment activated, and run
+Ensure that you have your environment activated, and run
 ```bash
 sbatch scripts/generate_activations.sh [MODEL_CONFIG_PATH]
 ```
@@ -43,6 +56,11 @@ When this completes, run
 sbatch scripts/benchmark.sh [MODEL_CONFIG_PATH]
 ```
 (We separate the two jobs, as only the former requires a GPU.) The results will populate `outputs/results/[model]`.
+
+To run unit tests locally without Docker:
+```bash
+make test-local
+```
 
 ## Benchmarking a Suite of Models
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ torch
 torch-pca
 torchvision
 osfclient
+pandas
 scikit-learn
 matplotlib
 tqdm


### PR DESCRIPTION
## Summary
- add a Dockerfile for a reproducible Python 3.11 environment
- add a .dockerignore to keep Docker build context small
- expand the Makefile with Docker-focused targets: build, test, test-local, shell, and help
- update README setup docs to include Docker + Make workflow
- add missing pandas dependency used by tests

## Validation
- make test-local (same pre-existing baseline failures: 14 failed, 32 passed)
- make build (succeeds)
- make test (runs in Docker; same pre-existing baseline failures: 14 failed, 32 passed)

## Notes
- running bare pytest still collects reliab_test.py, which requires local dataset files and fails in environments without that dataset; this PR keeps behavior unchanged and scopes Make targets to tests/.