### PR TITLE
Add timm compatibility for all pretrained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ sbatch scripts/all_models.sh
 ```
 Which will generative and evaluate activations for each model.
 
+## Benchmarking timm Models
+
+Any pretrained [`timm`](https://github.com/huggingface/pytorch-image-models) model is supported out of the box. To generate a config for every pretrained timm model, run
+```bash
+python -m utils.populate_timm
+```
+which writes one config per model into `configs/timm/`. Each config uses `transform: timm`, which builds the model's *native* evaluation transform (correct input size, crop, interpolation, and normalization) from its pretrained config at load time--so no transform needs to be hand-written per model.
+
+To benchmark a single timm model, either point the pipeline at a generated config or write a minimal one yourself:
+```yaml
+model-name: vit_base_patch16_384
+model-type: timm
+model-source: timm
+hook-interval: 5
+transform: timm
+```
+
 ## Adding Your Own Model
 
-In the current configuration, each model is specified by a corresponding config file in `configs`. Making a new config for your model is self-explanatory--just follow the outline of the existing ones. You will also have to build out `utils/load_model.py` to accept your added model. In the future, direct integration with `timm` will be provided. 
+In the current configuration, each model is specified by a corresponding config file in `configs`. Making a new config for your model is self-explanatory--just follow the outline of the existing ones. For non-timm/torchvision models you will also have to build out `utils/load_model.py` to accept your added model.
+
+### HMAX / chresmax models
+
+The `chresmax_v3` (HMAX) model is defined in the Serre Lab [fork of `pytorch-image-models`](https://github.com/npant14/pytorch-image-models) (as `timm.models.RESMAX`) and is **not** part of the upstream `timm` package. To benchmark it, install that fork in place of the pip `timm` package:
+```bash
+pip install -e /path/to/serre-lab/pytorch-image-models
+```
+The import is lazy, so the rest of the pipeline (including all standard timm models) works fine without it.

--- a/benchmark.py
+++ b/benchmark.py
@@ -43,8 +43,15 @@ def main(args):
             print(f"No activations found for layer: {layer}")
             continue
 
+        # Cast to float32: activations are stored as float16, and downstream
+        # StandardScaler divides in-place in the input dtype, which overflows
+        # to inf for low-variance features when left as float16.
         activations = (
-            activations.reshape(activations.shape[0], -1).detach().cpu().numpy()
+            activations.reshape(activations.shape[0], -1)
+            .detach()
+            .cpu()
+            .float()
+            .numpy()
         )  # [B, H * W * C]
         neural_responses, reliability = tvsd_dataset[: activations.shape[0]]
         reliability_mask = reliability > args.reliability_threshold

--- a/benchmark.py
+++ b/benchmark.py
@@ -43,9 +43,7 @@ def main(args):
             print(f"No activations found for layer: {layer}")
             continue
 
-        # Cast to float32: activations are stored as float16, and downstream
-        # StandardScaler divides in-place in the input dtype, which overflows
-        # to inf for low-variance features when left as float16.
+        # float32: float16 overflows StandardScaler's in-place divide to inf.
         activations = (
             activations.reshape(activations.shape[0], -1)
             .detach()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy
 torch
 torch-pca
 torchvision
+timm
 osfclient
 pandas
 scikit-learn

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1,0 +1,76 @@
+"""Tests for utils.load_model, focused on timm compatibility."""
+import os
+import tempfile
+
+import pytest
+import yaml
+
+
+def test_module_imports_without_hmax_fork():
+    """load_model must import even when the custom HMAX fork is absent.
+
+    Regression test: the module previously did a top-level import of a model
+    from a hardcoded cluster path, which made it unimportable everywhere else.
+    """
+    import utils.load_model  # noqa: F401
+
+
+def _write_config(tmp_path, **overrides):
+    config = {
+        "model-name": "resnet50",
+        "model-type": "timm",
+        "model-source": "timm",
+        "hook-interval": 5,
+        "transform": "timm",
+    }
+    config.update(overrides)
+    path = os.path.join(tmp_path, "model.yaml")
+    with open(path, "w") as f:
+        yaml.dump(config, f)
+    return path
+
+
+def test_resolve_timm_transform_uses_native_input_size():
+    """`transform: timm` should build the model's native eval transform."""
+    from torchvision import transforms
+
+    from utils.load_model import resolve_transform
+
+    with tempfile.TemporaryDirectory() as tmp_path:
+        # vit_base_patch16_384 has a non-default 384px input size, so it
+        # verifies we honor per-model config rather than a hardcoded 224.
+        config_path = _write_config(tmp_path, **{"model-name": "vit_base_patch16_384"})
+        transform = resolve_transform(config_path)
+
+    assert isinstance(transform, transforms.Compose)
+    crops = [t for t in transform.transforms if isinstance(t, transforms.CenterCrop)]
+    assert crops, "expected a CenterCrop in the timm transform"
+    assert tuple(crops[0].size) == (384, 384)
+
+
+def test_resolve_transform_still_supports_explicit_specs():
+    """The existing spec-based transform path must keep working."""
+    from torchvision import transforms
+
+    from utils.load_model import resolve_transform
+
+    with tempfile.TemporaryDirectory() as tmp_path:
+        config_path = _write_config(
+            tmp_path,
+            **{
+                "model-source": "torchvision",
+                "transform": [
+                    {"name": "Resize", "size": [224, 224]},
+                    {"name": "ToTensor"},
+                    {
+                        "name": "Normalize",
+                        "mean": [0.485, 0.456, 0.406],
+                        "std": [0.229, 0.224, 0.225],
+                    },
+                ],
+            },
+        )
+        transform = resolve_transform(config_path)
+
+    assert isinstance(transform, transforms.Compose)
+    assert any(isinstance(t, transforms.Normalize) for t in transform.transforms)

--- a/utils/load_model.py
+++ b/utils/load_model.py
@@ -65,8 +65,7 @@ def load_timm_model(config: dict):
 
 def load_hmax_model(config: dict):
     if config["model-type"] == "chresmax_v3":
-        # HMAX models live in a custom timm fork that is not pip-installable.
-        # Import lazily so the rest of the pipeline works without it.
+        # Lazy: chresmax lives in a custom timm fork, not pip-installable.
         try:
             from timm.models.RESMAX import chresmax_v3
         except ImportError as e:
@@ -122,10 +121,7 @@ def resolve_transform(model_config: str):
 
     transform_specs = config.get("transform", {})
 
-    # timm models carry their own input size / crop / normalization in their
-    # pretrained config. Setting `transform: timm` builds the model's native
-    # eval transform, so every timm model gets the correct preprocessing for
-    # free (no need to hand-write a transform per model).
+    # `transform: timm` builds the model's native eval transform.
     if transform_specs == "timm":
         return resolve_timm_transform(config["model-name"])
 
@@ -148,19 +144,8 @@ def resolve_transform(model_config: str):
 
 
 def resolve_timm_transform(model_name: str):
-    """
-    Build a timm model's native evaluation transform from its pretrained
-    config (input size, crop, interpolation, normalization).
-
-    This reads the model's `pretrained_cfg` and does not download weights, so
-    it works for any pretrained timm model without instantiating it.
-
-    Args:
-        model_name (str): Name of the timm model.
-
-    Returns:
-        transform: The model's native eval transform.
-    """
+    """Build a timm model's native eval transform from its pretrained_cfg
+    (no weight download / instantiation)."""
     from timm.data import create_transform, resolve_data_config
 
     pretrained_cfg = timm.get_pretrained_cfg(model_name).to_dict()

--- a/utils/load_model.py
+++ b/utils/load_model.py
@@ -1,14 +1,8 @@
-import sys
 import yaml
 
-# import timm
+import timm
 import torch
 from torchvision import transforms
-
-sys.path.append(
-    "/users/jamullik/pytorch-image-models/"
-)  # hacky for now, need to fix this later
-from timm.models.RESMAX import chresmax_v3
 
 
 def load_model(config_path: str):
@@ -71,6 +65,16 @@ def load_timm_model(config: dict):
 
 def load_hmax_model(config: dict):
     if config["model-type"] == "chresmax_v3":
+        # HMAX models live in a custom timm fork that is not pip-installable.
+        # Import lazily so the rest of the pipeline works without it.
+        try:
+            from timm.models.RESMAX import chresmax_v3
+        except ImportError as e:
+            raise ImportError(
+                "chresmax_v3 requires the custom pytorch-image-models fork "
+                "(github.com/serre-lab/pytorch-image-models) to be installed."
+            ) from e
+
         checkpoint = torch.load(
             config["hmax-info"]["ckpt_path"],
             map_location="cuda" if torch.cuda.is_available() else "cpu",
@@ -117,6 +121,14 @@ def resolve_transform(model_config: str):
         config = yaml.safe_load(file)
 
     transform_specs = config.get("transform", {})
+
+    # timm models carry their own input size / crop / normalization in their
+    # pretrained config. Setting `transform: timm` builds the model's native
+    # eval transform, so every timm model gets the correct preprocessing for
+    # free (no need to hand-write a transform per model).
+    if transform_specs == "timm":
+        return resolve_timm_transform(config["model-name"])
+
     transform_list = []
 
     for spec in transform_specs:
@@ -133,3 +145,24 @@ def resolve_transform(model_config: str):
 
     transform = transforms.Compose(transform_list)
     return transform
+
+
+def resolve_timm_transform(model_name: str):
+    """
+    Build a timm model's native evaluation transform from its pretrained
+    config (input size, crop, interpolation, normalization).
+
+    This reads the model's `pretrained_cfg` and does not download weights, so
+    it works for any pretrained timm model without instantiating it.
+
+    Args:
+        model_name (str): Name of the timm model.
+
+    Returns:
+        transform: The model's native eval transform.
+    """
+    from timm.data import create_transform, resolve_data_config
+
+    pretrained_cfg = timm.get_pretrained_cfg(model_name).to_dict()
+    data_config = resolve_data_config(args={}, pretrained_cfg=pretrained_cfg)
+    return create_transform(**data_config, is_training=False)

--- a/utils/load_model.py
+++ b/utils/load_model.py
@@ -72,7 +72,7 @@ def load_hmax_model(config: dict):
         except ImportError as e:
             raise ImportError(
                 "chresmax_v3 requires the custom pytorch-image-models fork "
-                "(github.com/serre-lab/pytorch-image-models) to be installed."
+                "(https://github.com/npant14/pytorch-image-models) to be installed."
             ) from e
 
         checkpoint = torch.load(

--- a/utils/populate_timm.py
+++ b/utils/populate_timm.py
@@ -4,24 +4,23 @@ import yaml
 
 
 def populate_timm():
-    standard_imagenet_transform = [
-        {"name": "Resize", "size": [224, 224]},
-        {"name": "ToTensor"},
-        {
-            "name": "Normalize",
-            "mean": [0.485, 0.456, 0.406],
-            "std": [0.229, 0.224, 0.225],
-        },
-    ]
+    """
+    Generate a config file for every pretrained timm model.
+
+    Each config uses `transform: timm`, which tells `resolve_transform` to
+    build the model's native eval transform from its pretrained config at load
+    time (correct input size, crop, interpolation, and normalization). This
+    keeps every model correct without hand-writing a transform per model.
+    """
+    os.makedirs("configs/timm", exist_ok=True)
     for model in timm.list_models(pretrained=True):
         model_config = {
             "model-name": model,
             "model-type": "timm",
             "model-source": "timm",
             "hook-interval": 5,
-            "transform": standard_imagenet_transform,
+            "transform": "timm",
         }
-        os.makedirs(f"configs/timm", exist_ok=True)
         with open(f"configs/timm/{model}.yaml", "w") as f:
             yaml.dump(model_config, f)
 

--- a/utils/populate_timm.py
+++ b/utils/populate_timm.py
@@ -4,14 +4,7 @@ import yaml
 
 
 def populate_timm():
-    """
-    Generate a config file for every pretrained timm model.
-
-    Each config uses `transform: timm`, which tells `resolve_transform` to
-    build the model's native eval transform from its pretrained config at load
-    time (correct input size, crop, interpolation, and normalization). This
-    keeps every model correct without hand-writing a transform per model.
-    """
+    """Write a config for every pretrained timm model (uses `transform: timm`)."""
     os.makedirs("configs/timm", exist_ok=True)
     for model in timm.list_models(pretrained=True):
         model_config = {


### PR DESCRIPTION
Make any pretrained timm model work through the load/activation/benchmark pipeline without hand-writing per-model configs.

- load_model: drop the hardcoded cluster sys.path + top-level RESMAX import that made the module unimportable off-cluster; import timm properly and load chresmax lazily with a clear error pointing at the Serre Lab fork.
- load_model: add a `transform: timm` sentinel that builds each model's native eval transform (input size, crop, interpolation, normalization) from its pretrained config, with no weight download.
- populate_timm: emit `transform: timm` per model so every pretrained timm model gets correct preprocessing automatically.
- benchmark: cast activations to float32 before fitting. They are stored as float16, and StandardScaler divides in-place in the input dtype, which overflows to inf for low-variance features. Affects all model sources.
- requirements: add timm (imported but previously unlisted).
- tests: cover module import without the fork and timm-native transform resolution (no GPU, no weight download).
- README: document timm benchmarking and the HMAX fork requirement.