### PR TITLE
Test-suite fixes + format/lint/type/test pre-commit gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Pre-commit gate: format (ruff) + lint (ruff) + types (mypy) + tests (pytest).
+# Install once with:  pre-commit install
+# Run against everything with:  pre-commit run --all-files
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-PyYAML]
+        # Config (files, ignore_missing_imports) lives in pyproject.toml.
+        pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,33 @@ IMAGE_TAG ?= latest
 
 DOCKER_IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
 
-.PHONY: help build test test-local shell cleanlogs cleantimm
+.PHONY: help build test test-local lint typecheck hooks shell cleanlogs cleantimm
 
 help:
 	@echo "Available targets:"
 	@echo "  make build      Build Docker image ($(DOCKER_IMAGE))"
 	@echo "  make test       Run unit tests in Docker"
 	@echo "  make test-local Run unit tests locally"
+	@echo "  make lint       Run ruff lint checks"
+	@echo "  make format     Format code with ruff"
+	@echo "  make typecheck  Run mypy type checks"
+	@echo "  make hooks      Install the pre-commit hooks"
 	@echo "  make shell      Open an interactive shell in the Docker image"
 	@echo "  make cleanlogs  Remove logs/*"
 	@echo "  make cleantimm  Remove configs/timm/*"
+
+lint:
+	ruff check .
+
+format:
+	ruff format .
+
+typecheck:
+	mypy
+
+hooks:
+	pre-commit install
+	@echo "Pre-commit hooks installed (lint + pytest run on every commit)"
 
 build:
 	docker build -t $(DOCKER_IMAGE) .

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,28 +1,21 @@
 import os
 import argparse
-import json
-from tqdm import tqdm
 import numpy as np
 import torch
-from torch.utils.data import DataLoader
 
 from utils.dataset import TVSD_Dataset
-from utils.hooks import Activations
-from utils.load_model import load_model, resolve_transform
+from utils.load_model import load_model
 from utils.brainscore import compute_brain_score
 
 
 def main(args):
-
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
 
     model, model_name, _ = load_model(args.model_config)
     # layers = [name for name, module in model.named_modules() if 'relu' not in name]
 
-    tvsd_dataset = TVSD_Dataset(
-        root_dir=args.root_dir, monkey=args.monkey, region=args.region
-    )
+    tvsd_dataset = TVSD_Dataset(root_dir=args.root_dir, monkey=args.monkey, region=args.region)
 
     layer_scores = {}
     activation_dir = f"{args.output_dir}/activations/TVSD/{model_name}"
@@ -32,9 +25,7 @@ def main(args):
         layer_dir = f"{activation_dir}/{layer}"
         activation_path = f"{layer_dir}/activations.pt"
         if not os.path.exists(activation_path):
-            print(
-                f"Activations for layer {layer} not found at {activation_path}. Skipping."
-            )
+            print(f"Activations for layer {layer} not found at {activation_path}. Skipping.")
             continue
         activations = torch.load(f"{layer_dir}/activations.pt", map_location=device)
         if activations is not None:
@@ -45,11 +36,7 @@ def main(args):
 
         # float32: float16 overflows StandardScaler's in-place divide to inf.
         activations = (
-            activations.reshape(activations.shape[0], -1)
-            .detach()
-            .cpu()
-            .float()
-            .numpy()
+            activations.reshape(activations.shape[0], -1).detach().cpu().float().numpy()
         )  # [B, H * W * C]
         neural_responses, reliability = tvsd_dataset[: activations.shape[0]]
         reliability_mask = reliability > args.reliability_threshold
@@ -81,9 +68,7 @@ def main(args):
     print("Final Layer Scores:")
     for layer, scores in layer_scores.items():
         print(f"{layer}: Score = {scores['score']}, Std = {scores['std']}")
-    results_file = (
-        f"{args.output_dir}/results/{model_name}/{args.monkey}_arr_{args.region}.csv"
-    )
+    results_file = f"{args.output_dir}/results/{model_name}/{args.monkey}_arr_{args.region}.csv"
     os.makedirs(os.path.dirname(results_file), exist_ok=True)
     with open(results_file, "w") as f:
         f.write("Layer,Score,Std\n")

--- a/generate_activations.py
+++ b/generate_activations.py
@@ -1,11 +1,8 @@
 import os
 import argparse
-import json
 from tqdm import tqdm
-import numpy as np
 import torch
 from torch.utils.data import DataLoader
-from typing import Optional
 
 from utils.dataset import TVSD_Dataset
 from utils.hooks import Activations
@@ -30,22 +27,13 @@ def main(args):
     )
     activations.register(model, hook_layers)
 
-    tvsd_dataset = TVSD_Dataset(
-        root_dir=args.root_dir, monkey=args.monkey, region=args.region
-    )
-    things_dataset = tvsd_dataset.get_things(
-        things_path=args.things_path, transform=transform
-    )
-    things_loader = DataLoader(
-        things_dataset, batch_size=args.batch_size, shuffle=False
-    )
-    shuffled_things_loader = DataLoader(
-        things_dataset, batch_size=args.batch_size, shuffle=True
-    )
+    tvsd_dataset = TVSD_Dataset(root_dir=args.root_dir, monkey=args.monkey, region=args.region)
+    things_dataset = tvsd_dataset.get_things(things_path=args.things_path, transform=transform)
+    things_loader = DataLoader(things_dataset, batch_size=args.batch_size, shuffle=False)
+    shuffled_things_loader = DataLoader(things_dataset, batch_size=args.batch_size, shuffle=True)
 
     if args.pca_components is not None:
         print("Training IPCA models...")
-        max_pca_train_batches = args.max_pca_train_batches
         activations.set_training_mode(True)
 
         for i, batch in tqdm(enumerate(shuffled_things_loader), desc="Training IPCA"):
@@ -110,18 +98,14 @@ if __name__ == "__main__":
         default=f"{os.getcwd()}/data/THINGS/object_images",
         help="Path to the THINGS dataset.",
     )
-    parser.add_argument(
-        "--batch_size", type=int, default=16, help="Batch size for the DataLoader."
-    )
+    parser.add_argument("--batch_size", type=int, default=16, help="Batch size for the DataLoader.")
     parser.add_argument(
         "--output_dir",
         type=str,
         default=f"{os.getcwd()}/outputs",
         help="Directory to save activations.",
     )
-    parser.add_argument(
-        "--max_batches", type=int, help="Maximum number of batches to process."
-    )
+    parser.add_argument("--max_batches", type=int, help="Maximum number of batches to process.")
     parser.add_argument(
         "--max_pca_train_batches",
         type=str,

--- a/notebooks/reliab_test.py
+++ b/notebooks/reliab_test.py
@@ -12,10 +12,7 @@ print(f"Reliability (first 5): {dataset_precomputed.reliability[:5]}")
 # Test 2: Recomputed reliability
 print("\n=== Test 2: Recomputed Reliability ===")
 dataset_recomputed = TVSD_TestDataset(
-    region="IT",
-    recompute_reliability=True,
-    n_boot=30,
-    random_state=42
+    region="IT", recompute_reliability=True, n_boot=30, random_state=42
 )
 print(f"Responses shape: {dataset_recomputed.responses.shape}")
 print(f"Reliability shape: {dataset_recomputed.reliability.shape}")
@@ -31,10 +28,7 @@ print(f"Correlation: {corr:.4f}, p-value: {pval:.4e}")
 # Test 4: Test with different random seed (should give different results)
 print("\n=== Test 4: Different Random Seed ===")
 dataset_recomputed2 = TVSD_TestDataset(
-    region="IT",
-    recompute_reliability=True,
-    n_boot=30,
-    random_state=99
+    region="IT", recompute_reliability=True, n_boot=30, random_state=99
 )
 recomp_rels2 = dataset_recomputed2.reliability.numpy()
 print(f"Same seed correlation: {pearsonr(recomp_rels, recomp_rels)[0]:.4f}")
@@ -43,10 +37,7 @@ print(f"Different seed correlation: {pearsonr(recomp_rels, recomp_rels2)[0]:.4f}
 # Test 5: Same seed should give identical results
 print("\n=== Test 5: Reproducibility with Same Seed ===")
 dataset_recomputed3 = TVSD_TestDataset(
-    region="IT",
-    recompute_reliability=True,
-    n_boot=30,
-    random_state=42
+    region="IT", recompute_reliability=True, n_boot=30, random_state=42
 )
 recomp_rels3 = dataset_recomputed3.reliability.numpy()
 print(f"Identical (seed=42 vs seed=42): {np.allclose(recomp_rels, recomp_rels3)}")

--- a/notebooks/reliability_comparison_histogram.py
+++ b/notebooks/reliability_comparison_histogram.py
@@ -5,14 +5,15 @@ This script compares precomputed and computed neuroid reliabilities for the TVSD
 """
 
 import sys
-sys.path.append('..')
+
+sys.path.append("..")
 
 from utils.dataset import TVSD_TestDataset
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import pearsonr
 
-plt.style.use('seaborn-v0_8-darkgrid')
+plt.style.use("seaborn-v0_8-darkgrid")
 
 # Load dataset with precomputed reliability
 print("Loading precomputed reliabilities...")
@@ -22,10 +23,7 @@ precomp_rels = dataset_precomputed.reliability.numpy()
 # Load dataset with recomputed reliability
 print("Computing reliabilities...")
 dataset_recomputed = TVSD_TestDataset(
-    region="IT",
-    recompute_reliability=True,
-    n_boot=30,
-    random_state=42
+    region="IT", recompute_reliability=True, n_boot=30, random_state=42
 )
 recomp_rels = dataset_recomputed.reliability.numpy()
 
@@ -43,44 +41,60 @@ print(f"Mean absolute difference: {np.mean(np.abs(precomp_rels - recomp_rels)):.
 fig, axes = plt.subplots(2, 2, figsize=(14, 10))
 
 # Histogram 1: Precomputed reliabilities
-axes[0, 0].hist(precomp_rels, bins=50, alpha=0.7, color='blue', edgecolor='black')
-axes[0, 0].set_xlabel('Reliability', fontsize=12)
-axes[0, 0].set_ylabel('Frequency', fontsize=12)
-axes[0, 0].set_title('Precomputed Neuroid Reliabilities', fontsize=14, fontweight='bold')
-axes[0, 0].axvline(precomp_rels.mean(), color='red', linestyle='--', linewidth=2, label=f'Mean: {precomp_rels.mean():.3f}')
+axes[0, 0].hist(precomp_rels, bins=50, alpha=0.7, color="blue", edgecolor="black")
+axes[0, 0].set_xlabel("Reliability", fontsize=12)
+axes[0, 0].set_ylabel("Frequency", fontsize=12)
+axes[0, 0].set_title("Precomputed Neuroid Reliabilities", fontsize=14, fontweight="bold")
+axes[0, 0].axvline(
+    precomp_rels.mean(),
+    color="red",
+    linestyle="--",
+    linewidth=2,
+    label=f"Mean: {precomp_rels.mean():.3f}",
+)
 axes[0, 0].legend()
 axes[0, 0].grid(True, alpha=0.3)
 
 # Histogram 2: Recomputed reliabilities
-axes[0, 1].hist(recomp_rels, bins=50, alpha=0.7, color='green', edgecolor='black')
-axes[0, 1].set_xlabel('Reliability', fontsize=12)
-axes[0, 1].set_ylabel('Frequency', fontsize=12)
-axes[0, 1].set_title('Recomputed Neuroid Reliabilities', fontsize=14, fontweight='bold')
-axes[0, 1].axvline(recomp_rels.mean(), color='red', linestyle='--', linewidth=2, label=f'Mean: {recomp_rels.mean():.3f}')
+axes[0, 1].hist(recomp_rels, bins=50, alpha=0.7, color="green", edgecolor="black")
+axes[0, 1].set_xlabel("Reliability", fontsize=12)
+axes[0, 1].set_ylabel("Frequency", fontsize=12)
+axes[0, 1].set_title("Recomputed Neuroid Reliabilities", fontsize=14, fontweight="bold")
+axes[0, 1].axvline(
+    recomp_rels.mean(),
+    color="red",
+    linestyle="--",
+    linewidth=2,
+    label=f"Mean: {recomp_rels.mean():.3f}",
+)
 axes[0, 1].legend()
 axes[0, 1].grid(True, alpha=0.3)
 
 # Histogram 3: Overlayed comparison
-axes[1, 0].hist(precomp_rels, bins=50, alpha=0.5, color='blue', edgecolor='black', label='Precomputed')
-axes[1, 0].hist(recomp_rels, bins=50, alpha=0.5, color='green', edgecolor='black', label='Recomputed')
-axes[1, 0].set_xlabel('Reliability', fontsize=12)
-axes[1, 0].set_ylabel('Frequency', fontsize=12)
-axes[1, 0].set_title('Overlayed Comparison', fontsize=14, fontweight='bold')
+axes[1, 0].hist(
+    precomp_rels, bins=50, alpha=0.5, color="blue", edgecolor="black", label="Precomputed"
+)
+axes[1, 0].hist(
+    recomp_rels, bins=50, alpha=0.5, color="green", edgecolor="black", label="Recomputed"
+)
+axes[1, 0].set_xlabel("Reliability", fontsize=12)
+axes[1, 0].set_ylabel("Frequency", fontsize=12)
+axes[1, 0].set_title("Overlayed Comparison", fontsize=14, fontweight="bold")
 axes[1, 0].legend(fontsize=11)
 axes[1, 0].grid(True, alpha=0.3)
 
 # Scatter plot: Precomputed vs Recomputed
 axes[1, 1].scatter(precomp_rels, recomp_rels, alpha=0.5, s=20)
-axes[1, 1].plot([0, 1], [0, 1], 'r--', linewidth=2, label='y=x')
-axes[1, 1].set_xlabel('Precomputed Reliability', fontsize=12)
-axes[1, 1].set_ylabel('Recomputed Reliability', fontsize=12)
-axes[1, 1].set_title(f'Correlation: r={corr:.4f}', fontsize=14, fontweight='bold')
+axes[1, 1].plot([0, 1], [0, 1], "r--", linewidth=2, label="y=x")
+axes[1, 1].set_xlabel("Precomputed Reliability", fontsize=12)
+axes[1, 1].set_ylabel("Recomputed Reliability", fontsize=12)
+axes[1, 1].set_title(f"Correlation: r={corr:.4f}", fontsize=14, fontweight="bold")
 axes[1, 1].legend()
 axes[1, 1].grid(True, alpha=0.3)
-axes[1, 1].set_aspect('equal', adjustable='box')
+axes[1, 1].set_aspect("equal", adjustable="box")
 
 plt.tight_layout()
-plt.savefig('notebooks/reliability_comparison.png', dpi=300, bbox_inches='tight')
+plt.savefig("notebooks/reliability_comparison.png", dpi=300, bbox_inches="tight")
 print("\nFigure saved as 'notebooks/reliability_comparison.png'")
 
 # Statistical Summary
@@ -119,17 +133,19 @@ print(f"Max abs difference:  {np.abs(diff).max():.4f}")
 fig, ax = plt.subplots(figsize=(10, 6))
 
 diff = precomp_rels - recomp_rels
-ax.hist(diff, bins=50, alpha=0.7, color='purple', edgecolor='black')
-ax.axvline(0, color='red', linestyle='--', linewidth=2, label='Zero difference')
-ax.axvline(diff.mean(), color='orange', linestyle='--', linewidth=2, label=f'Mean: {diff.mean():.4f}')
-ax.set_xlabel('Difference (Precomputed - Recomputed)', fontsize=12)
-ax.set_ylabel('Frequency', fontsize=12)
-ax.set_title('Distribution of Reliability Differences', fontsize=14, fontweight='bold')
+ax.hist(diff, bins=50, alpha=0.7, color="purple", edgecolor="black")
+ax.axvline(0, color="red", linestyle="--", linewidth=2, label="Zero difference")
+ax.axvline(
+    diff.mean(), color="orange", linestyle="--", linewidth=2, label=f"Mean: {diff.mean():.4f}"
+)
+ax.set_xlabel("Difference (Precomputed - Recomputed)", fontsize=12)
+ax.set_ylabel("Frequency", fontsize=12)
+ax.set_title("Distribution of Reliability Differences", fontsize=14, fontweight="bold")
 ax.legend(fontsize=11)
 ax.grid(True, alpha=0.3)
 
 plt.tight_layout()
-plt.savefig('notebooks/reliability_difference_distribution.png', dpi=300, bbox_inches='tight')
+plt.savefig("notebooks/reliability_difference_distribution.png", dpi=300, bbox_inches="tight")
 print("Figure saved as 'notebooks/reliability_difference_distribution.png'")
 
 plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+# Match the codebase; don't reformat the world.
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+# Real-bug rules only: pyflakes (F) + pycodestyle syntax errors (E9).
+# Keep the gate low-noise so it stays trustworthy.
+select = ["F", "E9"]
+
+[tool.mypy]
+python_version = "3.11"
+# Lenient/gradual: third-party ML libs (torch, numpy, timm) ship incomplete
+# stubs, so we don't fail on missing imports or require full annotation.
+ignore_missing_imports = true
+# Only type-check first-party source, not tests (mocks add noise).
+files = ["utils", "benchmark.py", "generate_activations.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,8 @@ pyyaml
 opencv-python
 pytest
 pytest-cov
+ruff
+mypy
+types-PyYAML
+pre-commit
 osfclient

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,10 +1,9 @@
 """Tests for utils.aggregate module."""
-import pytest
+
 import pandas as pd
 import os
 import tempfile
 import shutil
-from unittest.mock import patch, MagicMock
 
 from utils.aggregate import aggregate_results, collect_results
 
@@ -24,116 +23,110 @@ class TestCollectResults:
     def test_collect_single_region(self):
         """Test collecting results from single region."""
         # Create test CSV files for monkeyF V1 (arrays 0-7)
-        df1 = pd.DataFrame({
-            'Layer': ['layer1', 'layer2'],
-            'Score': [0.5, 0.6]
-        })
-        df1.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_0.csv'), index=False)
+        df1 = pd.DataFrame({"Layer": ["layer1", "layer2"], "Score": [0.5, 0.6]})
+        df1.to_csv(os.path.join(self.test_dir, "monkeyF_arr_0.csv"), index=False)
 
-        df2 = pd.DataFrame({
-            'Layer': ['layer1', 'layer2'],
-            'Score': [0.55, 0.65]
-        })
-        df2.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_1.csv'), index=False)
+        df2 = pd.DataFrame({"Layer": ["layer1", "layer2"], "Score": [0.55, 0.65]})
+        df2.to_csv(os.path.join(self.test_dir, "monkeyF_arr_1.csv"), index=False)
 
-        results = collect_results(self.test_dir, monkey='monkeyF')
+        results = collect_results(self.test_dir, monkey="monkeyF")
 
-        assert 'V1' in results
-        assert len(results['V1']) == 2
-        assert isinstance(results['V1'][0], pd.DataFrame)
+        assert "V1" in results
+        assert len(results["V1"]) == 2
+        assert isinstance(results["V1"][0], pd.DataFrame)
 
     def test_collect_multiple_regions(self):
         """Test collecting results from multiple regions."""
         # V1: arrays 0-7
-        df_v1 = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.5]})
-        df_v1.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_0.csv'), index=False)
+        df_v1 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df_v1.to_csv(os.path.join(self.test_dir, "monkeyF_arr_0.csv"), index=False)
 
         # IT: arrays 8-12
-        df_it = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.6]})
-        df_it.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_8.csv'), index=False)
+        df_it = pd.DataFrame({"Layer": ["layer1"], "Score": [0.6]})
+        df_it.to_csv(os.path.join(self.test_dir, "monkeyF_arr_8.csv"), index=False)
 
         # V4: arrays 13-15
-        df_v4 = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.7]})
-        df_v4.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_13.csv'), index=False)
+        df_v4 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.7]})
+        df_v4.to_csv(os.path.join(self.test_dir, "monkeyF_arr_13.csv"), index=False)
 
-        results = collect_results(self.test_dir, monkey='monkeyF')
+        results = collect_results(self.test_dir, monkey="monkeyF")
 
-        assert 'V1' in results
-        assert 'IT' in results
-        assert 'V4' in results
-        assert len(results['V1']) == 1
-        assert len(results['IT']) == 1
-        assert len(results['V4']) == 1
+        assert "V1" in results
+        assert "IT" in results
+        assert "V4" in results
+        assert len(results["V1"]) == 1
+        assert len(results["IT"]) == 1
+        assert len(results["V4"]) == 1
 
     def test_collect_filters_by_monkey(self):
         """Test that only specified monkey's results are collected."""
         # MonkeyF file
-        df_f = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.5]})
-        df_f.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_0.csv'), index=False)
+        df_f = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df_f.to_csv(os.path.join(self.test_dir, "monkeyF_arr_0.csv"), index=False)
 
         # MonkeyN file
-        df_n = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.6]})
-        df_n.to_csv(os.path.join(self.test_dir, 'monkeyN_arr_0.csv'), index=False)
+        df_n = pd.DataFrame({"Layer": ["layer1"], "Score": [0.6]})
+        df_n.to_csv(os.path.join(self.test_dir, "monkeyN_arr_0.csv"), index=False)
 
-        results_f = collect_results(self.test_dir, monkey='monkeyF')
-        results_n = collect_results(self.test_dir, monkey='monkeyN')
+        results_f = collect_results(self.test_dir, monkey="monkeyF")
+        results_n = collect_results(self.test_dir, monkey="monkeyN")
 
         # MonkeyF should only have 1 file
-        assert 'V1' in results_f
-        assert len(results_f['V1']) == 1
+        assert "V1" in results_f
+        assert len(results_f["V1"]) == 1
 
         # MonkeyN should only have 1 file
-        assert 'V1' in results_n
-        assert len(results_n['V1']) == 1
+        assert "V1" in results_n
+        assert len(results_n["V1"]) == 1
 
     def test_collect_ignores_aggregate_files(self):
         """Test that aggregate files are ignored."""
         # Regular file
-        df1 = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.5]})
-        df1.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_0.csv'), index=False)
+        df1 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df1.to_csv(os.path.join(self.test_dir, "monkeyF_arr_0.csv"), index=False)
 
         # Aggregate file (should be ignored)
-        df_agg = pd.DataFrame({'model': ['model1'], 'score': [0.8]})
-        df_agg.to_csv(os.path.join(self.test_dir, 'agg_results_V1.csv'), index=False)
+        df_agg = pd.DataFrame({"model": ["model1"], "score": [0.8]})
+        df_agg.to_csv(os.path.join(self.test_dir, "agg_results_V1.csv"), index=False)
 
-        results = collect_results(self.test_dir, monkey='monkeyF')
+        results = collect_results(self.test_dir, monkey="monkeyF")
 
         # Should only collect 1 file (not the aggregate)
-        assert 'V1' in results
-        assert len(results['V1']) == 1
+        assert "V1" in results
+        assert len(results["V1"]) == 1
 
     def test_collect_empty_directory(self):
         """Test collecting from empty directory."""
-        results = collect_results(self.test_dir, monkey='monkeyF')
+        results = collect_results(self.test_dir, monkey="monkeyF")
         assert results == {}
 
     def test_collect_no_matching_monkey(self):
         """Test collecting when no files match the monkey."""
-        df = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.5]})
-        df.to_csv(os.path.join(self.test_dir, 'monkeyF_arr_0.csv'), index=False)
+        df = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df.to_csv(os.path.join(self.test_dir, "monkeyF_arr_0.csv"), index=False)
 
-        results = collect_results(self.test_dir, monkey='monkeyN')
+        results = collect_results(self.test_dir, monkey="monkeyN")
         assert results == {}
 
     def test_collect_monkeyN_regions(self):
         """Test collecting results for monkeyN with correct region mapping."""
         # V1: arrays 0-7
-        df_v1 = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.5]})
-        df_v1.to_csv(os.path.join(self.test_dir, 'monkeyN_arr_0.csv'), index=False)
+        df_v1 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df_v1.to_csv(os.path.join(self.test_dir, "monkeyN_arr_0.csv"), index=False)
 
         # V4: arrays 8-11
-        df_v4 = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.6]})
-        df_v4.to_csv(os.path.join(self.test_dir, 'monkeyN_arr_8.csv'), index=False)
+        df_v4 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.6]})
+        df_v4.to_csv(os.path.join(self.test_dir, "monkeyN_arr_8.csv"), index=False)
 
         # IT: arrays 12-15
-        df_it = pd.DataFrame({'Layer': ['layer1'], 'Score': [0.7]})
-        df_it.to_csv(os.path.join(self.test_dir, 'monkeyN_arr_12.csv'), index=False)
+        df_it = pd.DataFrame({"Layer": ["layer1"], "Score": [0.7]})
+        df_it.to_csv(os.path.join(self.test_dir, "monkeyN_arr_12.csv"), index=False)
 
-        results = collect_results(self.test_dir, monkey='monkeyN')
+        results = collect_results(self.test_dir, monkey="monkeyN")
 
-        assert 'V1' in results
-        assert 'V4' in results
-        assert 'IT' in results
+        assert "V1" in results
+        assert "V4" in results
+        assert "IT" in results
 
 
 class TestAggregateResults:
@@ -151,152 +144,137 @@ class TestAggregateResults:
     def test_aggregate_single_model_single_region(self):
         """Test aggregating results for single model and region."""
         # Create model directory
-        model_dir = os.path.join(self.test_dir, 'model1')
+        model_dir = os.path.join(self.test_dir, "model1")
         os.makedirs(model_dir)
 
         # Create test data - V1 region (arrays 0-7 for monkeyF)
-        df = pd.DataFrame({
-            'Layer': ['layer1', 'layer2', 'layer1', 'layer2'],
-            'Score': [0.5, 0.6, 0.52, 0.58]
-        })
-        df.to_csv(os.path.join(model_dir, 'monkeyF_arr_0.csv'), index=False)
+        df = pd.DataFrame(
+            {"Layer": ["layer1", "layer2", "layer1", "layer2"], "Score": [0.5, 0.6, 0.52, 0.58]}
+        )
+        df.to_csv(os.path.join(model_dir, "monkeyF_arr_0.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
         # Check that aggregate file was created
-        agg_file = os.path.join(self.test_dir, 'agg_results_V1.csv')
+        agg_file = os.path.join(self.test_dir, "agg_results_V1.csv")
         assert os.path.exists(agg_file)
 
         # Check contents
         agg_df = pd.read_csv(agg_file)
         assert len(agg_df) == 1
-        assert 'model' in agg_df.columns
-        assert 'best_layer' in agg_df.columns
-        assert 'best_layer_score' in agg_df.columns
-        assert 'best_layer_std' in agg_df.columns
+        assert "model" in agg_df.columns
+        assert "best_layer" in agg_df.columns
+        assert "best_layer_score" in agg_df.columns
+        assert "best_layer_std" in agg_df.columns
 
     def test_aggregate_multiple_models(self):
         """Test aggregating results for multiple models."""
         # Create model directories
-        model1_dir = os.path.join(self.test_dir, 'model1')
-        model2_dir = os.path.join(self.test_dir, 'model2')
+        model1_dir = os.path.join(self.test_dir, "model1")
+        model2_dir = os.path.join(self.test_dir, "model2")
         os.makedirs(model1_dir)
         os.makedirs(model2_dir)
 
         # Create test data for both models
-        df1 = pd.DataFrame({
-            'Layer': ['layer1', 'layer2'],
-            'Score': [0.5, 0.6]
-        })
-        df1.to_csv(os.path.join(model1_dir, 'monkeyF_arr_0.csv'), index=False)
+        df1 = pd.DataFrame({"Layer": ["layer1", "layer2"], "Score": [0.5, 0.6]})
+        df1.to_csv(os.path.join(model1_dir, "monkeyF_arr_0.csv"), index=False)
 
-        df2 = pd.DataFrame({
-            'Layer': ['layer1', 'layer2'],
-            'Score': [0.7, 0.8]
-        })
-        df2.to_csv(os.path.join(model2_dir, 'monkeyF_arr_0.csv'), index=False)
+        df2 = pd.DataFrame({"Layer": ["layer1", "layer2"], "Score": [0.7, 0.8]})
+        df2.to_csv(os.path.join(model2_dir, "monkeyF_arr_0.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
         # Check aggregate file
-        agg_file = os.path.join(self.test_dir, 'agg_results_V1.csv')
+        agg_file = os.path.join(self.test_dir, "agg_results_V1.csv")
         agg_df = pd.read_csv(agg_file)
 
         assert len(agg_df) == 2
-        assert set(agg_df['model']) == {'model1', 'model2'}
+        assert set(agg_df["model"]) == {"model1", "model2"}
 
     def test_aggregate_best_layer_selection(self):
         """Test that best layer is correctly selected."""
-        model_dir = os.path.join(self.test_dir, 'model1')
+        model_dir = os.path.join(self.test_dir, "model1")
         os.makedirs(model_dir)
 
         # Create data where layer2 is better than layer1
-        df = pd.DataFrame({
-            'Layer': ['layer1', 'layer1', 'layer2', 'layer2'],
-            'Score': [0.3, 0.35, 0.8, 0.85]  # layer2 has higher mean
-        })
-        df.to_csv(os.path.join(model_dir, 'monkeyF_arr_0.csv'), index=False)
+        df = pd.DataFrame(
+            {
+                "Layer": ["layer1", "layer1", "layer2", "layer2"],
+                "Score": [0.3, 0.35, 0.8, 0.85],  # layer2 has higher mean
+            }
+        )
+        df.to_csv(os.path.join(model_dir, "monkeyF_arr_0.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
-        agg_df = pd.read_csv(os.path.join(self.test_dir, 'agg_results_V1.csv'))
-        assert agg_df.iloc[0]['best_layer'] == 'layer2'
-        assert agg_df.iloc[0]['best_layer_score'] > 0.8
+        agg_df = pd.read_csv(os.path.join(self.test_dir, "agg_results_V1.csv"))
+        assert agg_df.iloc[0]["best_layer"] == "layer2"
+        assert agg_df.iloc[0]["best_layer_score"] > 0.8
 
     def test_aggregate_multiple_regions(self):
         """Test aggregating results across multiple regions."""
-        model_dir = os.path.join(self.test_dir, 'model1')
+        model_dir = os.path.join(self.test_dir, "model1")
         os.makedirs(model_dir)
 
         # V1 data (array 0)
-        df_v1 = pd.DataFrame({
-            'Layer': ['layer1'],
-            'Score': [0.5]
-        })
-        df_v1.to_csv(os.path.join(model_dir, 'monkeyF_arr_0.csv'), index=False)
+        df_v1 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df_v1.to_csv(os.path.join(model_dir, "monkeyF_arr_0.csv"), index=False)
 
         # IT data (array 8)
-        df_it = pd.DataFrame({
-            'Layer': ['layer1'],
-            'Score': [0.6]
-        })
-        df_it.to_csv(os.path.join(model_dir, 'monkeyF_arr_8.csv'), index=False)
+        df_it = pd.DataFrame({"Layer": ["layer1"], "Score": [0.6]})
+        df_it.to_csv(os.path.join(model_dir, "monkeyF_arr_8.csv"), index=False)
 
         # V4 data (array 13)
-        df_v4 = pd.DataFrame({
-            'Layer': ['layer1'],
-            'Score': [0.7]
-        })
-        df_v4.to_csv(os.path.join(model_dir, 'monkeyF_arr_13.csv'), index=False)
+        df_v4 = pd.DataFrame({"Layer": ["layer1"], "Score": [0.7]})
+        df_v4.to_csv(os.path.join(model_dir, "monkeyF_arr_13.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
         # Check that all three aggregate files were created
-        assert os.path.exists(os.path.join(self.test_dir, 'agg_results_V1.csv'))
-        assert os.path.exists(os.path.join(self.test_dir, 'agg_results_IT.csv'))
-        assert os.path.exists(os.path.join(self.test_dir, 'agg_results_V4.csv'))
+        assert os.path.exists(os.path.join(self.test_dir, "agg_results_V1.csv"))
+        assert os.path.exists(os.path.join(self.test_dir, "agg_results_IT.csv"))
+        assert os.path.exists(os.path.join(self.test_dir, "agg_results_V4.csv"))
 
     def test_aggregate_empty_results_dir(self):
         """Test aggregating from empty results directory."""
         # Should not crash
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
         # No aggregate files should be created
-        csv_files = [f for f in os.listdir(self.test_dir) if f.endswith('.csv')]
+        csv_files = [f for f in os.listdir(self.test_dir) if f.endswith(".csv")]
         assert len(csv_files) == 0
 
     def test_aggregate_model_without_region(self):
         """Test that models without certain regions are skipped for those regions."""
-        model_dir = os.path.join(self.test_dir, 'model1')
+        model_dir = os.path.join(self.test_dir, "model1")
         os.makedirs(model_dir)
 
         # Only V1 data
-        df = pd.DataFrame({
-            'Layer': ['layer1'],
-            'Score': [0.5]
-        })
-        df.to_csv(os.path.join(model_dir, 'monkeyF_arr_0.csv'), index=False)
+        df = pd.DataFrame({"Layer": ["layer1"], "Score": [0.5]})
+        df.to_csv(os.path.join(model_dir, "monkeyF_arr_0.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
         # Only V1 aggregate should exist
-        assert os.path.exists(os.path.join(self.test_dir, 'agg_results_V1.csv'))
-        assert not os.path.exists(os.path.join(self.test_dir, 'agg_results_IT.csv'))
-        assert not os.path.exists(os.path.join(self.test_dir, 'agg_results_V4.csv'))
+        assert os.path.exists(os.path.join(self.test_dir, "agg_results_V1.csv"))
+        assert not os.path.exists(os.path.join(self.test_dir, "agg_results_IT.csv"))
+        assert not os.path.exists(os.path.join(self.test_dir, "agg_results_V4.csv"))
 
     def test_aggregate_std_calculation(self):
         """Test that standard deviation is correctly calculated."""
-        model_dir = os.path.join(self.test_dir, 'model1')
+        model_dir = os.path.join(self.test_dir, "model1")
         os.makedirs(model_dir)
 
         # Data with known std
-        df = pd.DataFrame({
-            'Layer': ['layer1', 'layer1', 'layer1'],
-            'Score': [0.4, 0.5, 0.6]  # std should be ~0.1
-        })
-        df.to_csv(os.path.join(model_dir, 'monkeyF_arr_0.csv'), index=False)
+        df = pd.DataFrame(
+            {
+                "Layer": ["layer1", "layer1", "layer1"],
+                "Score": [0.4, 0.5, 0.6],  # std should be ~0.1
+            }
+        )
+        df.to_csv(os.path.join(model_dir, "monkeyF_arr_0.csv"), index=False)
 
-        aggregate_results(self.test_dir, monkey='monkeyF')
+        aggregate_results(self.test_dir, monkey="monkeyF")
 
-        agg_df = pd.read_csv(os.path.join(self.test_dir, 'agg_results_V1.csv'))
-        assert abs(agg_df.iloc[0]['best_layer_std'] - 0.1) < 0.01
+        agg_df = pd.read_csv(os.path.join(self.test_dir, "agg_results_V1.csv"))
+        assert abs(agg_df.iloc[0]["best_layer_std"] - 0.1) < 0.01

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,13 +1,11 @@
 """Tests for utils.dataset module."""
+
 import pytest
 import numpy as np
 import torch
-from unittest.mock import Mock, patch, MagicMock
-import h5py
-import tempfile
-import os
+from unittest.mock import patch
 
-from utils.dataset import TVSD_BaseDataset, TVSD_Dataset, TVSD_TestDataset, THINGS_Dataset
+from utils.dataset import TVSD_BaseDataset, TVSD_TestDataset, THINGS_Dataset
 
 
 class TestTHINGSDataset:
@@ -36,62 +34,62 @@ class TestTVSDBaseDataset:
 
     def test_get_arrays_from_region_monkeyF_V1(self):
         """Test array indices for monkeyF V1 region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(0, 8))
 
     def test_get_arrays_from_region_monkeyF_IT(self):
         """Test array indices for monkeyF IT region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="IT")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(8, 13))
 
     def test_get_arrays_from_region_monkeyF_V4(self):
         """Test array indices for monkeyF V4 region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V4")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(13, 16))
 
     def test_get_arrays_from_region_monkeyN_V1(self):
         """Test array indices for monkeyN V1 region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyN", region="V1")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(0, 8))
 
     def test_get_arrays_from_region_monkeyN_V4(self):
         """Test array indices for monkeyN V4 region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyN", region="V4")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(8, 12))
 
     def test_get_arrays_from_region_monkeyN_IT(self):
         """Test array indices for monkeyN IT region."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyN", region="IT")
                 arrays = dataset._get_arrays_from_region()
                 assert arrays == list(range(12, 16))
 
     def test_get_arrays_from_region_invalid(self):
         """Test invalid region raises ValueError."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
             with pytest.raises(ValueError, match="Invalid region"):
                 TVSD_BaseDataset(monkey="monkeyF", region="INVALID")
 
     def test_get_array_idxs(self):
         """Test that array_idxs are correctly computed from arrays."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 # V1 has arrays 0-7, each array has 64 channels
                 # So indices should be 0-511
@@ -103,8 +101,10 @@ class TestTVSDBaseDataset:
         responses = torch.randn(100, 512)
         reliability = torch.randn(512)
 
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(responses, reliability)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_BaseDataset, "_get_responses", return_value=(responses, reliability)
+            ):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 response, rel = dataset[0]
                 assert torch.allclose(response, responses[0])
@@ -115,8 +115,10 @@ class TestTVSDBaseDataset:
         responses = torch.randn(100, 512)
         reliability = torch.randn(512)
 
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(responses, reliability)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_BaseDataset, "_get_responses", return_value=(responses, reliability)
+            ):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 response, rel = dataset[0:10]
                 assert torch.allclose(response, responses[0:10])
@@ -127,8 +129,10 @@ class TestTVSDBaseDataset:
         responses = torch.randn(100, 512)
         reliability = torch.randn(512)
 
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(responses, reliability)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_BaseDataset, "_get_responses", return_value=(responses, reliability)
+            ):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 indices = [0, 5, 10]
                 response, rel = dataset[indices]
@@ -140,8 +144,10 @@ class TestTVSDBaseDataset:
         responses = torch.randn(100, 512)
         reliability = torch.randn(512)
 
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(responses, reliability)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_BaseDataset, "_get_responses", return_value=(responses, reliability)
+            ):
                 dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 with pytest.raises(TypeError, match="Unsupported index type"):
                     _ = dataset["invalid"]
@@ -156,8 +162,8 @@ class TestTVSDTestDataset:
         np.random.seed(42)
         data = np.random.randn(30, 100, 10)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(data, n_boot=10, random_state=42)
 
@@ -169,8 +175,8 @@ class TestTVSDTestDataset:
         np.random.seed(42)
         data = np.random.randn(30, 100, 10)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 rel1 = dataset._compute_reliability(data, n_boot=10, random_state=42)
                 rel2 = dataset._compute_reliability(data, n_boot=10, random_state=42)
@@ -182,8 +188,8 @@ class TestTVSDTestDataset:
         np.random.seed(42)
         data = np.random.randn(30, 100, 10)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 rel1 = dataset._compute_reliability(data, n_boot=10, random_state=42)
                 rel2 = dataset._compute_reliability(data, n_boot=10, random_state=99)
@@ -191,6 +197,7 @@ class TestTVSDTestDataset:
                 # Should be different but correlated
                 assert not np.allclose(rel1, rel2)
                 from scipy.stats import pearsonr
+
                 corr, _ = pearsonr(rel1, rel2)
                 assert corr > 0.8  # Should be highly correlated
 
@@ -199,8 +206,8 @@ class TestTVSDTestDataset:
         np.random.seed(42)
         data = np.random.randn(30, 100, 10)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(
                     data, n_boot=10, n_reps_subset=15, random_state=42
@@ -211,15 +218,19 @@ class TestTVSDTestDataset:
 
     def test_init_recompute_reliability_params(self):
         """Test initialization parameters for recompute_reliability."""
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses', return_value=(np.zeros((30, 100, 10)), torch.zeros(10))):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_TestDataset,
+                "_get_responses",
+                return_value=(np.zeros((30, 100, 10)), torch.zeros(10)),
+            ):
                 dataset = TVSD_TestDataset(
                     monkey="monkeyF",
                     region="V1",
                     recompute_reliability=True,
                     n_boot=50,
                     n_reps_subset=20,
-                    random_state=123
+                    random_state=123,
                 )
 
                 assert dataset.recompute_reliability == True
@@ -229,8 +240,12 @@ class TestTVSDTestDataset:
 
     def test_init_default_params(self):
         """Test default initialization parameters."""
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses', return_value=(np.zeros((30, 100, 10)), torch.zeros(10))):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(
+                TVSD_TestDataset,
+                "_get_responses",
+                return_value=(np.zeros((30, 100, 10)), torch.zeros(10)),
+            ):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 assert dataset.recompute_reliability == False
@@ -244,8 +259,8 @@ class TestDatasetIntegration:
 
     def test_array_channel_mapping_consistency(self):
         """Test that array-to-channel mapping is consistent across regions."""
-        with patch.object(TVSD_BaseDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_BaseDataset, '_get_responses', return_value=(None, None)):
+        with patch.object(TVSD_BaseDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_BaseDataset, "_get_responses", return_value=(None, None)):
                 # Test that total channels add up to 1024 (16 arrays * 64 channels)
                 v1_dataset = TVSD_BaseDataset(monkey="monkeyF", region="V1")
                 it_dataset = TVSD_BaseDataset(monkey="monkeyF", region="IT")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,93 @@
+"""Tests for utils.hooks.Activations (layer resolution + capture logic)."""
+
+import torch
+import torch.nn as nn
+
+from utils.hooks import Activations
+
+
+def _toy_model():
+    # index 0: Linear(4->3), index 1: ReLU, index 2: Linear(3->2)
+    return nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 2))
+
+
+class TestResolveLayer:
+    def test_digit_path_indexes_sequential(self):
+        model = _toy_model()
+        act = Activations(output_dir="x", model_name="m", dataset_name="d")
+        layer = act._resolve_layer(model, "0")
+        assert isinstance(layer, nn.Linear)
+        assert layer.in_features == 4
+
+    def test_attribute_path(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.backbone = nn.Sequential(nn.Linear(4, 3))
+
+        act = Activations("x", "m", "d")
+        layer = act._resolve_layer(Net(), "backbone.0")
+        assert isinstance(layer, nn.Linear)
+
+
+class TestRegister:
+    def test_register_attaches_hooks(self):
+        model = _toy_model()
+        act = Activations("x", "m", "d")
+        act.register(model, ["0", "2"])
+        assert len(act.hooks) == 2
+
+    def test_unresolvable_layer_is_skipped(self):
+        model = _toy_model()
+        act = Activations("x", "m", "d")
+        # Should not raise; the bad name is skipped and no hook is attached.
+        act.register(model, ["nonexistent"])
+        assert len(act.hooks) == 0
+
+
+class TestInferenceCapture:
+    def test_forward_stores_float16_activations_per_batch(self):
+        model = _toy_model()
+        act = Activations("x", "m", "d")
+        act.register(model, ["0", "2"])
+
+        act.set_batch(0)
+        _ = model(torch.randn(5, 4))
+        act.finalize_batch_inference()
+
+        captured = act.get()
+        assert set(captured.keys()) == {"0", "2"}
+        tensor = captured["0"][0][0]
+        # layer 0 is Linear(4->3), flattened over batch of 5
+        assert tuple(tensor.shape) == (5, 3)
+        assert tensor.dtype == torch.float16
+
+    def test_clear_resets_state(self):
+        model = _toy_model()
+        act = Activations("x", "m", "d")
+        act.register(model, ["0"])
+        act.set_batch(0)
+        _ = model(torch.randn(2, 4))
+        act.finalize_batch_inference()
+        assert act.get()
+
+        act.clear()
+        assert act.get() == {}
+        assert act.hooks == []
+
+
+class TestTrainingPCA:
+    def test_ipca_components_clamped_to_feature_count(self):
+        model = _toy_model()
+        # Ask for more PCA components than the layer has features.
+        act = Activations("x", "m", "d", pca_components=10)
+        act.register(model, ["0"])
+        act.set_training_mode(True)
+
+        act.set_batch(0)
+        _ = model(torch.randn(5, 4))
+        act.finalize_batch_training()
+
+        ipca = act.get_ipca_models()["0"]
+        # layer 0 emits 3 features, so n_components is clamped from 10 to 3.
+        assert ipca.n_components == 3

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1,4 +1,5 @@
 """Tests for utils.load_model, focused on timm compatibility."""
+
 import os
 import tempfile
 
@@ -48,6 +49,20 @@ def test_resolve_timm_transform_uses_native_input_size():
     assert tuple(crops[0].size) == (384, 384)
 
 
+def test_resolve_timm_transform_unknown_model_raises_clearly():
+    """An unknown timm model name must raise a clear ValueError.
+
+    Regression: get_pretrained_cfg returns None for unknown models, which
+    previously blew up with an opaque AttributeError on `.to_dict()`.
+    """
+    from utils.load_model import resolve_transform
+
+    with tempfile.TemporaryDirectory() as tmp_path:
+        config_path = _write_config(tmp_path, **{"model-name": "definitely_not_a_timm_model"})
+        with pytest.raises(ValueError, match="Unknown timm model"):
+            resolve_transform(config_path)
+
+
 def test_resolve_transform_still_supports_explicit_specs():
     """The existing spec-based transform path must keep working."""
     from torchvision import transforms
@@ -74,3 +89,51 @@ def test_resolve_transform_still_supports_explicit_specs():
 
     assert isinstance(transform, transforms.Compose)
     assert any(isinstance(t, transforms.Normalize) for t in transform.transforms)
+
+
+def test_load_model_unknown_source_raises():
+    """An unrecognized model-source must fail loudly, not silently."""
+    from utils.load_model import load_model
+
+    with tempfile.TemporaryDirectory() as tmp_path:
+        config_path = _write_config(tmp_path, **{"model-source": "bogus"})
+        with pytest.raises(NotImplementedError):
+            load_model(config_path)
+
+
+def test_resolve_transform_unsupported_spec_raises():
+    """An unknown transform spec name must raise rather than be dropped."""
+    from utils.load_model import resolve_transform
+
+    with tempfile.TemporaryDirectory() as tmp_path:
+        config_path = _write_config(
+            tmp_path,
+            **{
+                "model-source": "torchvision",
+                "transform": [{"name": "NotARealTransform"}],
+            },
+        )
+        with pytest.raises(NotImplementedError, match="NotARealTransform"):
+            resolve_transform(config_path)
+
+
+def test_load_hmax_unsupported_type_raises():
+    """load_hmax_model only knows chresmax_v3; others must raise."""
+    from utils.load_model import load_hmax_model
+
+    with pytest.raises(NotImplementedError):
+        load_hmax_model({"model-type": "unknown_hmax", "model-name": "x"})
+
+
+def test_load_hmax_chresmax_reports_missing_fork():
+    """When the custom timm fork is absent, chresmax_v3 must raise a clear
+    ImportError pointing at the fork -- not an opaque error deeper in the load."""
+    from utils.load_model import load_hmax_model
+
+    try:
+        import timm.models.RESMAX  # noqa: F401
+    except ImportError:
+        with pytest.raises(ImportError, match="fork"):
+            load_hmax_model({"model-type": "chresmax_v3"})
+    else:  # pragma: no cover - only when the fork is actually installed
+        pytest.skip("custom timm fork is installed; missing-fork path not exercised")

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,5 +1,5 @@
 """Tests for reliability computation functions."""
-import pytest
+
 import numpy as np
 import torch
 from scipy.stats import pearsonr
@@ -18,8 +18,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 20
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(data, n_boot=20, random_state=42)
 
@@ -33,10 +33,12 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 5
         base_response = np.random.randn(n_stim, n_neu)
         # All repetitions are identical (plus tiny noise)
-        data = np.array([base_response + np.random.randn(n_stim, n_neu) * 0.01 for _ in range(n_reps)])
+        data = np.array(
+            [base_response + np.random.randn(n_stim, n_neu) * 0.01 for _ in range(n_reps)]
+        )
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(data, n_boot=20, random_state=42)
 
@@ -50,8 +52,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 10
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(data, n_boot=30, random_state=42)
 
@@ -65,8 +67,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 10
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 rel1 = dataset._compute_reliability(data, n_boot=20, random_state=42)
@@ -81,8 +83,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 10
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 rel1 = dataset._compute_reliability(data, n_boot=20, random_state=42)
@@ -101,8 +103,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 10
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 # Compute with few bootstraps multiple times
@@ -130,8 +132,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 30, 100, 10
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 # Compute with all reps
@@ -155,8 +157,8 @@ class TestReliabilityComputation:
         n_reps, n_stim, n_neu = 2, 2, 1
         data = np.random.randn(n_reps, n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                 reliability = dataset._compute_reliability(data, n_boot=5, random_state=42)
 
@@ -175,8 +177,8 @@ class TestReliabilityComputation:
         for n_reps, n_stim, n_neu in test_cases:
             data = np.random.randn(n_reps, n_stim, n_neu)
 
-            with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-                with patch.object(TVSD_TestDataset, '_get_responses'):
+            with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+                with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                     dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
                     reliability = dataset._compute_reliability(data, n_boot=10, random_state=42)
 
@@ -190,17 +192,19 @@ class TestReliabilityComputation:
         # Create data with known reliability structure
         true_response = np.random.randn(n_stim, n_neu)
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=[]):
-            with patch.object(TVSD_TestDataset, '_get_responses'):
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=[]):
+            with patch.object(TVSD_TestDataset, "_get_responses", return_value=(None, None)):
                 dataset = TVSD_TestDataset(monkey="monkeyF", region="V1")
 
                 reliabilities = []
                 for n_reps in [5, 10, 20, 30]:
                     # Create data with noise
-                    data = np.array([
-                        true_response + np.random.randn(n_stim, n_neu) * 0.5
-                        for _ in range(n_reps)
-                    ])
+                    data = np.array(
+                        [
+                            true_response + np.random.randn(n_stim, n_neu) * 0.5
+                            for _ in range(n_reps)
+                        ]
+                    )
 
                     rel = dataset._compute_reliability(data, n_boot=20, random_state=42)
                     reliabilities.append(np.mean(rel))
@@ -222,16 +226,17 @@ class TestReliabilityIntegration:
         test_data = np.random.randn(n_reps, n_stim, n_neu)
         precomputed_rel = np.random.rand(n_neu) * 0.5 + 0.3  # Random reliability in [0.3, 0.8]
 
-        with patch.object(TVSD_TestDataset, '_get_paths', return_value=['img.jpg'] * n_stim):
-            with patch.object(TVSD_TestDataset, '_get_responses') as mock_responses:
+        with patch.object(TVSD_TestDataset, "_get_paths", return_value=["img.jpg"] * n_stim):
+            with patch.object(TVSD_TestDataset, "_get_responses") as mock_responses:
                 # Mock precomputed reliability path
-                mock_responses.return_value = (test_data, torch.tensor(precomputed_rel, dtype=torch.float32))
+                mock_responses.return_value = (
+                    test_data,
+                    torch.tensor(precomputed_rel, dtype=torch.float32),
+                )
 
                 # Create dataset with precomputed reliability
                 dataset_precomputed = TVSD_TestDataset(
-                    monkey="monkeyF",
-                    region="V1",
-                    recompute_reliability=False
+                    monkey="monkeyF", region="V1", recompute_reliability=False
                 )
 
                 # Create dataset with recomputed reliability
@@ -240,7 +245,7 @@ class TestReliabilityIntegration:
                     region="V1",
                     recompute_reliability=True,
                     n_boot=30,
-                    random_state=42
+                    random_state=42,
                 )
 
                 # Extract reliabilities

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,76 @@
+"""Tests for utils.utils helpers (get_region, rgetattr)."""
+
+import pytest
+
+from utils.utils import get_region, rgetattr
+
+
+class TestGetRegion:
+    """get_region maps (monkey, array index) -> brain region.
+
+    aggregate.collect_results depends on this mapping, so it is worth
+    pinning down directly.
+    """
+
+    @pytest.mark.parametrize(
+        "array, expected",
+        [(0, "V1"), (7, "V1"), (8, "IT"), (12, "IT"), (13, "V4"), (15, "V4")],
+    )
+    def test_monkeyF_ranges(self, array, expected):
+        assert get_region("monkeyF", array) == expected
+
+    @pytest.mark.parametrize(
+        "array, expected",
+        [(0, "V1"), (7, "V1"), (8, "V4"), (11, "V4"), (12, "IT"), (15, "IT")],
+    )
+    def test_monkeyN_ranges(self, array, expected):
+        assert get_region("monkeyN", array) == expected
+
+    def test_monkeyF_and_monkeyN_differ(self):
+        # Array 8 is IT for monkeyF but V4 for monkeyN -- the mapping is
+        # per-monkey, not shared.
+        assert get_region("monkeyF", 8) == "IT"
+        assert get_region("monkeyN", 8) == "V4"
+
+    def test_out_of_range_index_raises(self):
+        with pytest.raises(ValueError, match="Invalid array index"):
+            get_region("monkeyF", 16)
+
+    def test_unknown_monkey_raises(self):
+        # Unknown monkey -> empty mapping -> no range matches -> ValueError.
+        with pytest.raises(ValueError, match="Invalid array index"):
+            get_region("monkeyX", 0)
+
+
+class TestRgetattr:
+    """rgetattr resolves a whitespace-separated attribute path with a default.
+
+    Note: the current implementation splits on whitespace (path.split()),
+    not on ".", so these tests document the actual behavior.
+    """
+
+    class _Node:
+        pass
+
+    def _nested(self):
+        root = self._Node()
+        root.child = self._Node()
+        root.child.value = 42
+        return root
+
+    def test_single_attribute(self):
+        obj = self._Node()
+        obj.value = 7
+        assert rgetattr(obj, "value", default=-1) == 7
+
+    def test_nested_attribute_whitespace_path(self):
+        root = self._nested()
+        assert rgetattr(root, "child value", default=-1) == 42
+
+    def test_missing_attribute_returns_default(self):
+        obj = self._Node()
+        assert rgetattr(obj, "does_not_exist", default="fallback") == "fallback"
+
+    def test_missing_nested_attribute_returns_default(self):
+        root = self._nested()
+        assert rgetattr(root, "child missing", default=None) is None

--- a/utils/aggregate.py
+++ b/utils/aggregate.py
@@ -33,9 +33,7 @@ def aggregate_results(results_dir: str, monkey: str = "monkeyF"):
                     "std_score": layer_results["Score"].std(),
                 }
             if layer_scores:
-                best_layer_info = max(
-                    layer_scores.values(), key=lambda x: x["mean_score"]
-                )
+                best_layer_info = max(layer_scores.values(), key=lambda x: x["mean_score"])
                 model_best_layers[model] = {
                     "best_layer": best_layer_info["layer"],
                     "best_layer_score": best_layer_info["mean_score"],
@@ -64,7 +62,7 @@ def collect_results(model_dir: str, monkey: str = "monkeyF"):
         - monkey[X]_arr_[Y].csv
         - ...
     """
-    results = {}
+    results: dict[str, list] = {}
     for file in os.listdir(model_dir):
         if file.endswith(".csv") and "agg" not in file:
             monkey_name = file.split("_")[0]

--- a/utils/brainscore.py
+++ b/utils/brainscore.py
@@ -1,16 +1,10 @@
-import torch
-import torch.nn.functional as F
 import numpy as np
-import matplotlib.pyplot as plt
 from time import time
-from tqdm import tqdm
 from scipy.stats import pearsonr, spearmanr
 from sklearn.model_selection import KFold
-from sklearn.metrics import r2_score
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
-from torchvision.transforms.functional import resize, to_pil_image
 
 
 def brain_score_pearsonr(Y_pred, Y_test):

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 
 
 class THINGS_Dataset(Dataset):
-    def __init__(self, root_dir: str, paths: list, transform: Callable = None):
+    def __init__(self, root_dir: str, paths: list, transform: Optional[Callable] = None):
         self.root_dir = root_dir
         self.paths = paths
         self.transform = transform
@@ -99,12 +99,7 @@ class TVSD_BaseDataset(Dataset):
             dataset = f[key]
             num_samples = dataset["things_path"].shape[0]
             paths = [
-                (
-                    f[dataset["things_path"][i][0]][()]
-                    .tobytes()
-                    .decode("utf-16")
-                    .replace("\\", "/")
-                )
+                (f[dataset["things_path"][i][0]][()].tobytes().decode("utf-16").replace("\\", "/"))
                 for i in range(num_samples)
             ]
         return paths
@@ -116,7 +111,7 @@ class TVSD_BaseDataset(Dataset):
     def get_things(
         self,
         things_path: str = "/users/jamullik/scratch/TVSD-real/data/object_images",
-        transform: Callable = None,
+        transform: Optional[Callable] = None,
     ) -> THINGS_Dataset:
         return THINGS_Dataset(things_path, self.paths, transform=transform)
 
@@ -153,9 +148,7 @@ class TVSD_Dataset(TVSD_BaseDataset):
             dataset = f["train_MUA"][()]
             print(f.keys())
             print("dataset shape", dataset.shape)
-            reliability = torch.mean(
-                torch.tensor(f["reliab"][()], dtype=torch.float32), dim=0
-            )
+            reliability = torch.mean(torch.tensor(f["reliab"][()], dtype=torch.float32), dim=0)
         # Train data: 2D indexing [samples, channels]
         return dataset[:, self.array_idxs], reliability[self.array_idxs]
 

--- a/utils/hooks.py
+++ b/utils/hooks.py
@@ -14,17 +14,17 @@ class Activations:
         dataset_name: str,
         pca_components: Optional[int] = None,
     ):
-        self.hooks = []
+        self.hooks: List = []
         self._active = True
         self._current_batch = None
         self.model_name = model_name
         self.dataset_name = dataset_name
-        self.activations = {}  # {layer_name: {1: activations, 2: ...}}
+        self.activations: Dict = {}  # {layer_name: {1: activations, 2: ...}}
         self.output_dir = output_dir
         self.ipca_models: Dict[str, IncrementalPCA] = {}
         self._training_mode = False
         self.pca_components = pca_components
-        self._training_activations = {}  # {layer_name: [activations]}
+        self._training_activations: Dict = {}  # {layer_name: [activations]}
 
     def set_batch(self, batch):
         self._current_batch = batch
@@ -56,7 +56,7 @@ class Activations:
     def _handle_inference_mode(self, layer_name: str, output: torch.Tensor):
         output_flat = output.reshape(output.shape[0], -1).detach().cpu()
         if not hasattr(self, "_inference_accum"):
-            self._inference_accum = {}
+            self._inference_accum: Dict = {}
         if layer_name not in self._inference_accum:
             self._inference_accum[layer_name] = []
         self._inference_accum[layer_name].append(output_flat)
@@ -88,9 +88,7 @@ class Activations:
                 concat = np.concatenate([a for a in activations_list], axis=1)
                 print(f"[DEBUG] Concatenated shape: {concat.shape}")
             except Exception as e:
-                print(
-                    f"[ERROR] Failed to concatenate activations for {layer_name}: {e}"
-                )
+                print(f"[ERROR] Failed to concatenate activations for {layer_name}: {e}")
                 continue
             # Adjust n_components if we have fewer features
             n_features = concat.shape[1]
@@ -134,12 +132,10 @@ class Activations:
             if activations:
                 try:
                     tensor = torch.cat(activations, dim=0)
-                except Exception as e:
+                except Exception:
                     print(f"[ERROR] Layer {layer_name} could not be stacked.")
-                    print(
-                        f"[ERROR] Shapes of activations: {[a.shape for a in activations]}"
-                    )
-                    print(f"[ERROR] Skipping saving for this layer.")
+                    print(f"[ERROR] Shapes of activations: {[a.shape for a in activations]}")
+                    print("[ERROR] Skipping saving for this layer.")
                     continue
 
                 file_path = f"{self.output_dir}/activations/{self.dataset_name}/{self.model_name}/{layer_name}/activations.pt"

--- a/utils/load_model.py
+++ b/utils/load_model.py
@@ -50,9 +50,7 @@ def load_torchvision_model(config: dict):
         model = inception_v3(weights="IMAGENET1K_V1")
         model_name = "inception_v3"
     else:
-        raise NotImplementedError(
-            f"Model {config['model-name']} is not supported in torchvision."
-        )
+        raise NotImplementedError(f"Model {config['model-name']} is not supported in torchvision.")
 
     return model, model_name
 
@@ -99,9 +97,7 @@ def load_hmax_model(config: dict):
         model.load_state_dict(checkpoint["state_dict"], strict=False)
         model_name = "chresmax_v3"
     else:
-        raise NotImplementedError(
-            f"Model {config['model-type']} is not supported in HMAX."
-        )
+        raise NotImplementedError(f"Model {config['model-type']} is not supported in HMAX.")
 
     return model, model_name
 
@@ -133,9 +129,7 @@ def resolve_transform(model_config: str):
         elif spec["name"] == "ToTensor":
             transform_list.append(transforms.ToTensor())
         elif spec["name"] == "Normalize":
-            transform_list.append(
-                transforms.Normalize(mean=spec["mean"], std=spec["std"])
-            )
+            transform_list.append(transforms.Normalize(mean=spec["mean"], std=spec["std"]))
         else:
             raise NotImplementedError(f"Transform {spec['name']} is not supported.")
 
@@ -148,6 +142,9 @@ def resolve_timm_transform(model_name: str):
     (no weight download / instantiation)."""
     from timm.data import create_transform, resolve_data_config
 
-    pretrained_cfg = timm.get_pretrained_cfg(model_name).to_dict()
+    cfg = timm.get_pretrained_cfg(model_name)
+    if cfg is None:
+        raise ValueError(f"Unknown timm model '{model_name}'; no pretrained config found.")
+    pretrained_cfg = cfg.to_dict()
     data_config = resolve_data_config(args={}, pretrained_cfg=pretrained_cfg)
     return create_transform(**data_config, is_training=False)


### PR DESCRIPTION
## Summary

Audits and repairs the test suite, then adds a quality gate (format → lint → types → tests) that runs on every commit.

### Test suite
- **Fixes 14 failing tests.** The reliability tests patched `TVSD_TestDataset._get_responses` without a `return_value`, so the unconfigured mock couldn't unpack into `(responses, reliability)` and the constructor raised `ValueError` before any test body ran. Suite now green.
- **New coverage** (all pure/deterministic, no data files or network):
  - `tests/test_utils.py` — `get_region` (every monkeyF/monkeyN range + error cases) and `rgetattr`. `aggregate.py` depends on `get_region` and previously had no direct test.
  - `tests/test_hooks.py` — `Activations` layer resolution, hook registration (incl. graceful skip of bad names), inference capture (float16, per-batch), and IPCA `n_components` clamping.
  - `tests/test_load_model.py` — error paths for unknown source / transform / hmax type, and the missing-fork `ImportError` for `chresmax_v3`.
- Moved `reliab_test.py` (a manual `print` script, not a pytest test) to `notebooks/`.

### Bug fix (found by mypy)
- `resolve_timm_transform` called `.to_dict()` on `timm.get_pretrained_cfg(...)`, which returns `None` for unknown models → opaque `AttributeError`. Now raises a clear `ValueError`, with a regression test.

### Tooling / pre-commit gate
- **ruff** — lint scoped to real-bug rules (`F`, `E9`) + `ruff format` (100-char).
- **mypy** — lenient, source-only (`ignore_missing_imports`, tests excluded); fixed ~9 annotation sites.
- **pytest** — full suite runs on commit.
- Config wired into `pyproject.toml`, `.pre-commit-config.yaml`, `requirements.txt`, and new `make lint` / `make format` / `make typecheck` / `make hooks` targets.

## Test plan
- `pre-commit run --all-files` → ruff, ruff-format, mypy, pytest all pass.
- `pytest tests` → **80 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)