### PR TITLE
Fix download_things.sh: pass password to unzip

### DIFF
--- a/scripts/download_things.sh
+++ b/scripts/download_things.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script downloads the THINGS dataset from OSF and unzips into the data directory.
+#
+# The OSF archive is password-protected. The password is public ("things4all"),
+# but can be overridden via the THINGS_ZIP_PASSWORD environment variable.
+THINGS_ZIP_PASSWORD="${THINGS_ZIP_PASSWORD:-things4all}"
 
 cd data
 mkdir -p THINGS
 cd THINGS
 export UNZIP_DISABLE_ZIPBOMB_DETECTION=TRUE # i know this is super sus but the zip file is safe
 osf -p jum2f fetch images_THINGS.zip
-unzip images_THINGS.zip
+unzip -o -P "$THINGS_ZIP_PASSWORD" images_THINGS.zip
 rm images_THINGS.zip


### PR DESCRIPTION
## Problem
The THINGS OSF archive (`images_THINGS.zip`, project `jum2f`) is password-protected, but `scripts/download_things.sh` ran `unzip images_THINGS.zip` with **no password** — so the download step always failed at unzip, then `rm`'d the archive. Confirmed while pulling the data to Oscar: the fetch succeeds (5.02 GB) but the stock script cannot unpack it.

## Fix
- Pass the (public) password `things4all` to `unzip -P`, overridable via `THINGS_ZIP_PASSWORD`.
- Add `set -euo pipefail` so a failed fetch/unzip aborts instead of proceeding to `rm` a missing/partial archive.
- `unzip -o` to overwrite cleanly on re-runs.

Verified end-to-end on Oscar: fetch + `unzip -P things4all` unpacks to `data/THINGS/object_images/` (1,854 concept folders, 26,107 images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)